### PR TITLE
Dropdown keyboard control

### DIFF
--- a/demo/demo_app.js
+++ b/demo/demo_app.js
@@ -76,6 +76,28 @@ render(
         'Open Recent',
         'Save'
       ]}/>
+      <br/>
+      <WSDropdown text="Simple Wide" type="select" filterable items={[
+        'New',
+        {
+          label: 'New From Template',
+          children: [
+            'item 2.1',
+            {
+              label: 'item 2.2',
+              children: [
+                'item 2.3.1',
+                'item 2.3.2',
+                'item 2.3.3',
+                'item 2.3.4'
+              ]
+            }
+          ]
+        },
+        'Open',
+        'Open Recent',
+        'Save'
+      ]}/>
       <br />
       <WSDropdown text="Input" type="select" width="50%" placeholder="tasd" value="222" inputOnly/>
       <br />

--- a/src/ws-date-picker/ws-date-picker.scss
+++ b/src/ws-date-picker/ws-date-picker.scss
@@ -6,6 +6,9 @@
     right: rem(10px);
     top: rem(10px);
   }
+  .icon-only {
+    vertical-align: baseline;
+  }
 }
 .flatpickr-calendar {
   position: absolute;

--- a/src/ws-dropdown/dropdown-input.js
+++ b/src/ws-dropdown/dropdown-input.js
@@ -45,6 +45,9 @@ export class DropdownInput extends Component {
    */
   componentDidMount() {
     this.input.addEventListener('change', event => event.stopPropagation());
+    this.input.addEventListener('keydown', this.onKeyDown);
+    this.input.addEventListener('blur', this.onChange);
+    this.button.addEventListener('click', this.onSubmit);
   }
 
   /**
@@ -53,6 +56,9 @@ export class DropdownInput extends Component {
    */
   componentWillUnmount() {
     this.input.removeEventListener('change', event => event.stopPropagation());
+    this.input.removeEventListener('keydown', this.onKeyDown);
+    this.input.removeEventListener('blur', this.onChange);
+    this.button.removeEventListener('click', this.onSubmit);
   }
 
   /**
@@ -60,7 +66,7 @@ export class DropdownInput extends Component {
    * @param {KeyboardEvent} event JavaScript Event object
    * @returns {Boolean}
    */
-  onKeyDown(event) {
+  onKeyDown = event => {
     if (event.which === KEY_ENTER) {
       this.onChange(event);
       this.onSubmit();
@@ -68,23 +74,33 @@ export class DropdownInput extends Component {
       return false;
     }
     return true;
-  }
+  };
 
   /**
    * Set input value to state
    * @param {KeyboardEvent} event JavaScript event object
    * @returns {void}
    */
-  onChange(event) {
+  onChange = event => {
     this.setState({value: event.target.value});
-  }
+  };
 
   /**
    * Called when enter or submit key is pressed
    * @returns {void}
    */
-  onSubmit() {
+  onSubmit = () => {
     this.props.handle('change', this.state.value);
+  };
+
+  /**
+   * Bind keyboard listener and focus input if available when dropdown opens
+   * @returns {void}
+   */
+  onOpen() {
+    if (this.input) {
+      this.input.focus();
+    }
   }
 
   /**
@@ -106,13 +122,11 @@ export class DropdownInput extends Component {
             type="text"
             defaultValue={this.state.value}
             placeholder={this.props.placeholder}
-            onKeyDown={event => this.onKeyDown(event)}
-            onBlur={event => this.onChange(event)}
             ref={element => { this.input = element; }}
           />
         </li>
         <li className="dropdown-submit" key="submit">
-          <button className="mod-small" onClick={() => this.onSubmit()}>OK</button>
+          <button className="mod-small" ref={element => { this.button = element; }}>OK</button>
         </li>
       </ul>
     );

--- a/src/ws-dropdown/dropdown-menu-item.js
+++ b/src/ws-dropdown/dropdown-menu-item.js
@@ -61,6 +61,14 @@ export class DropdownMenuItem extends Component {
   }
 
   /**
+   * Listen for clicks on dropdown item
+   * @returns {void}
+   */
+  componentDidMount() {
+    this.dropdownItem.addEventListener('click', this.onClick);
+  }
+
+  /**
    * Important to update the state when the items in menu changed.
    * When in the multi select a dropdown item is selected and stored (submitted) it will be filtered out
    * of the item list and shown in a separate value list. React doesn't created new components but reuses them.
@@ -73,12 +81,20 @@ export class DropdownMenuItem extends Component {
   }
 
   /**
+   * Listen for clicks on dropdown item
+   * @returns {void}
+   */
+  componentWillUnmount() {
+    this.dropdownItem.removeEventListener('click', this.onClick);
+  }
+
+  /**
    * Handle clicks on this dropdown item. This can trigger a back navigation, selecting the item on multi selects
    * or change the dropdown value for simple dropdown's
    * @param {MouseEvent} event JavaScript event object
    * @returns {void}
    */
-  onClick(event) {
+  onClick = event => {
     event.stopPropagation();
     // Do nothing if this item is disabled
     if (this.state.disabled) {
@@ -108,7 +124,7 @@ export class DropdownMenuItem extends Component {
       // Use this strategy to keep the reference of this.state (item) into dropdown-menu items[x]
       this.setState(this.state);
     }
-  }
+  };
 
   /**
    * This is required to propagate changes from child menu to parent menu.
@@ -138,7 +154,7 @@ export class DropdownMenuItem extends Component {
     return (
       <li
         className={itemClass}
-        onClick={event => this.onClick(event)}
+        ref={element => { this.dropdownItem = element; }}
       >
         <a className={anchorClass} href={this.state.href} title={this.state.title || this.state.label}>
           {(this.props.icon || this.state.icon) &&

--- a/src/ws-dropdown/dropdown-menu.js
+++ b/src/ws-dropdown/dropdown-menu.js
@@ -164,7 +164,7 @@ export class DropdownMenu extends Component {
   };
 
   /**
-   * Setting the input value as filter
+   * Sets the input value as filter
    * @param {KeyboardEvent} event JavaScript event object
    * @returns {void}
    */
@@ -235,7 +235,7 @@ export class DropdownMenu extends Component {
     }
     const visibleItems = filteredItems.length + valueLength;
     let correctedIndex = index;
-    // Ensure the index is in boundings of visible items (selected and non selected items)
+    // Ensure the index is within bounds of visible items (selected and non selected items)
     if (index >= visibleItems) {
       correctedIndex = 0;
     } else if (index < 0) {

--- a/src/ws-dropdown/ws-dropdown.js
+++ b/src/ws-dropdown/ws-dropdown.js
@@ -231,15 +231,15 @@ export class WSDropdown extends Component {
    * @returns {Object}
    */
   createState(props) {
+    const items = this.enrichItems(props.items);
+    let value = props.value;
     // Map value to the item to improve usability
-    if (typeof props.value === 'string' && props.type !== 'input') {
-      props.value = props.items.find(item => item.value === props.value);
+    if (typeof value === 'string' && props.type !== 'input') {
+      value = items.find(item => item.value === value);
     }
-    const state = {
-      text: this.getTextFromValue(props.value, props.text),
-      value: this.enrichItems(props.value),
-      items: this.enrichItems(props.items)
-    };
+    value = this.enrichItems(value);
+    const text = this.getTextFromValue(props.value, props.text);
+    const state = {text, value, items};
     // Set states to items in item list for passed values
     state.items.forEach(item => {
       // Check if item is is values or set it to false

--- a/src/ws-dropdown/ws-dropdown.js
+++ b/src/ws-dropdown/ws-dropdown.js
@@ -233,7 +233,7 @@ export class WSDropdown extends Component {
   createState(props) {
     const items = this.enrichItems(props.items);
     let value = props.value;
-    // Map value to the item to improve usability
+    // For better usability the value can be a primitive value matching a dropdown item value
     if (typeof value === 'string' && props.type !== 'input') {
       value = items.find(item => item.value === value);
     }
@@ -307,7 +307,7 @@ export class WSDropdown extends Component {
     this.dropdownContainer.style.height = 0;
     this.dropdownContainer.classList.add('mod-open');
     this.adjustSize(this.dropdownMenu.getHeight());
-    // Bind keyboard listener for keyboard navigation
+
     window.addEventListener('keydown', this.onGlobalKeyDown);
     // Forward open action to menu
     if (typeof this.dropdownMenu.onOpen === 'function') {
@@ -331,7 +331,7 @@ export class WSDropdown extends Component {
         this.dropdownMenu.clearSelections();
       }
     });
-    // Unbind keyboard listener
+
     window.addEventListener('keydown', this.onGlobalKeyDown);
     // Forward close action to menu
     if (typeof this.dropdownMenu.onClose === 'function') {

--- a/src/ws-dropdown/ws-dropdown.js
+++ b/src/ws-dropdown/ws-dropdown.js
@@ -68,6 +68,11 @@ export class WSDropdown extends Component {
   };
 
   /**
+   * @type {WSDropdown}
+   */
+  static openDropdown = null;
+
+  /**
    * @type {Object}
    */
   static childContextTypes = {
@@ -81,7 +86,6 @@ export class WSDropdown extends Component {
   constructor(props) {
     super(props);
     // Enforce value to be an array for consistent usage
-    this.opened = false;
     this.state = this.createState(props);
   }
 
@@ -100,7 +104,9 @@ export class WSDropdown extends Component {
    * @returns {void}
    */
   componentDidMount() {
-    window.addEventListener('click', this.onDocumentClick.bind(this));
+    this.element.addEventListener('click', this.onAnyEvent);
+    this.trigger.addEventListener('click', this.onTriggerClick);
+    window.addEventListener('click', this.onDocumentClick);
   }
 
   /**
@@ -117,7 +123,9 @@ export class WSDropdown extends Component {
    * @returns {void}
    */
   componentWillUnmount() {
-    window.removeEventListener('click', this.onDocumentClick.bind(this));
+    this.element.removeEventListener('click', this.onAnyEvent);
+    this.trigger.removeEventListener('click', this.onTriggerClick);
+    window.removeEventListener('click', this.onDocumentClick);
   }
 
   /**
@@ -125,7 +133,7 @@ export class WSDropdown extends Component {
    * @param {MouseEvent} event JavaScript event object
    * @returns {void}
    */
-  onDocumentClick(event) {
+  onDocumentClick = event => {
     let element = event.target;
     while (element && this.element !== element) {
       element = element.parentNode;
@@ -134,7 +142,45 @@ export class WSDropdown extends Component {
     if (!element) {
       this.close();
     }
-  }
+  };
+
+  /**
+   * Handle clicks on dropdown trigger
+   * @param {MouseEvent} event JavaScript event object
+   * @returns {void}
+   */
+  onTriggerClick = event => {
+    event.stopPropagation();
+    if (WSDropdown.openDropdown !== this) {
+      this.open();
+    } else {
+      this.close();
+    }
+  };
+
+  /**
+   * Prevent event to bubble up and keep it inside drop down
+   * @param {Event} event Event object
+   * @returns {void}
+   */
+  onAnyEvent = event => {
+    event.stopPropagation();
+  };
+
+  /**
+   * Handles global key down events when dropdown was opened
+   * @param {KeyboardEvent} event JavaScript event object
+   * @returns {void}
+   */
+  onGlobalKeyDown = event => {
+    switch (event.key) {
+      case 'Escape':
+        this.close();
+        break;
+      default:
+        break;
+    }
+  };
 
   /**
    * Get text from labels of selected items
@@ -151,7 +197,7 @@ export class WSDropdown extends Component {
         text = value.map(item => item.label || item).join(', ');
       } else if (value) {
         // Value can be object from dropdown item or simple string from input
-        text = value.label;
+        text = value.label || value;
       }
     }
     return text;
@@ -185,6 +231,10 @@ export class WSDropdown extends Component {
    * @returns {Object}
    */
   createState(props) {
+    // Map value to the item to improve usability
+    if (typeof props.value === 'string' && props.type !== 'input') {
+      props.value = props.items.find(item => item.value === props.value);
+    }
     const state = {
       text: this.getTextFromValue(props.value, props.text),
       value: this.enrichItems(props.value),
@@ -246,13 +296,23 @@ export class WSDropdown extends Component {
    * @returns {void}
    */
   open() {
-    if (this.opened || this.props.disabled) {
+    // Stop if this dropdown is already opened or close previous opened dropdown
+    if (WSDropdown.openDropdown === this || this.props.disabled) {
       return;
+    } else if (WSDropdown.openDropdown) {
+      WSDropdown.openDropdown.close();
     }
-    this.opened = true;
+
+    WSDropdown.openDropdown = this;
     this.dropdownContainer.style.height = 0;
     this.dropdownContainer.classList.add('mod-open');
     this.adjustSize(this.dropdownMenu.getHeight());
+    // Bind keyboard listener for keyboard navigation
+    window.addEventListener('keydown', this.onGlobalKeyDown);
+    // Forward open action to menu
+    if (typeof this.dropdownMenu.onOpen === 'function') {
+      this.dropdownMenu.onOpen();
+    }
   }
 
   /**
@@ -260,17 +320,23 @@ export class WSDropdown extends Component {
    * @returns {void}
    */
   close() {
-    if (!this.opened) {
+    if (WSDropdown.openDropdown !== this) {
       return;
     }
+    WSDropdown.openDropdown = null;
     this.animateElement(this.dropdownContainer, 'animate-close', container => {
-      this.opened = false;
       container.classList.remove('mod-open');
       // If this a multi select dropdown abort
       if (this.props.multiple) {
         this.dropdownMenu.clearSelections();
       }
     });
+    // Unbind keyboard listener
+    window.addEventListener('keydown', this.onGlobalKeyDown);
+    // Forward close action to menu
+    if (typeof this.dropdownMenu.onClose === 'function') {
+      this.dropdownMenu.onClose();
+    }
   }
 
   /**
@@ -322,7 +388,7 @@ export class WSDropdown extends Component {
         return (
           <a
             className={`dropdown-trigger ${disabledStyle}`}
-            onClick={() => this.open()}
+            ref={element => { this.trigger = element; }}
           >
             {icon} {this.state.text}
           </a>);
@@ -330,7 +396,7 @@ export class WSDropdown extends Component {
         return (
           <button
             className={`dropdown-trigger ${disabledStyle}`}
-            onClick={() => this.open()}
+            ref={element => { this.trigger = element; }}
           >
             {icon} {this.state.text}
           </button>);
@@ -338,7 +404,7 @@ export class WSDropdown extends Component {
         return (
           <div
             className={`dropdown-trigger select-box ${disabledStyle}`}
-            onClick={() => this.open()}
+            ref={element => { this.trigger = element; }}
           >
             {icon} {this.state.text}
           </div>);
@@ -347,7 +413,7 @@ export class WSDropdown extends Component {
         return (
           <a
             className={`dropdown-trigger ${disabledStyle}`}
-            onClick={() => this.open()}
+            ref={element => { this.trigger = element; }}
           >
             {icon}
           </a>);
@@ -396,7 +462,7 @@ export class WSDropdown extends Component {
         {this.renderTrigger()}
         <div
           className={`dropdown-container ${this.props.orientation}`}
-          style={{width: this.props.width || (isWide ? '100%' : 'auto')}}
+          style={{width: this.props.width || (isWide ? '100%' : '')}}
           ref={element => { if (element) { this.dropdownContainer = element; } }}
         >
           {this.renderContent()}

--- a/src/ws-header/ws-header.js
+++ b/src/ws-header/ws-header.js
@@ -235,14 +235,17 @@ export class WSHeader extends Component {
     return (
       <header className="ws-header" ref={element => { this.element = element; }}>
         <div className="level-1">
-          <div className="application-name">
+          <a // eslint-disable-line jsx-a11y/href-no-hash
+            className="application-name"
+            href="#"
+          >
             {this.props.appLogo &&
               <figure className="application-logo">
                 <img src={this.props.appLogo} alt="Application logo" />
               </figure>
             }
             {this.props.appName}
-          </div>
+          </a>
           <nav className="main-menu">
             <ul>
               {this.props.links.map((link, index) =>

--- a/tests/ws-dropdown/dropdown-menu.spec.js
+++ b/tests/ws-dropdown/dropdown-menu.spec.js
@@ -24,7 +24,7 @@ describe('A DropdownMenu', () => {
     expect(dm.getFilteredItems().length).toBe(2);
   });
 
-  it('get\'s the item for a selection index', () => {
+  it('gets the item for a selection index', () => {
     const items = [{label: 'test'}, {label: 'asd'}, {label: 'qwerty'}];
     const dm = new DropdownMenu({value: [], items});
     dm.context = {multiple: false};

--- a/tests/ws-dropdown/dropdown-menu.spec.js
+++ b/tests/ws-dropdown/dropdown-menu.spec.js
@@ -1,0 +1,54 @@
+import {React} from 'imports';
+import {DropdownMenu} from '../../src/ws-dropdown/dropdown-menu';
+
+describe('A DropdownMenu', () => {
+
+  it('filters items', () => {
+    const dm = new DropdownMenu({items: [{label: 't1'}, {label: 't2'}, {label: 't3', stored: true}]});
+    dm.context = {multiple: false};
+
+    // Get all items
+    dm.state.filter = 'irrelevant';
+    expect(dm.getFilteredItems().length).toBe(3);
+    // Get all items with filter string in label and not stored
+    dm.props.filterable = true;
+    dm.state.filter = '1';
+    expect(dm.getFilteredItems().length).toBe(1);
+    dm.state.filter = 't';
+    expect(dm.getFilteredItems().length).toBe(2);
+    // Get all not stored items
+    dm.context.multiple = true;
+    dm.props.filterable = false;
+    dm.state.filter = 'anything';
+    expect(dm.getFilteredItems().length).toBe(2);
+  });
+
+  it('get\'s the item for a selection index', () => {
+    const items = [{label: 'test'}, {label: 'asd'}, {label: 'qwerty'}];
+    const dm = new DropdownMenu({value: [], items});
+    dm.context = {multiple: false};
+
+    expect(dm.getItemAtIndex(0).item).toBe(items[0]);
+    expect(dm.getItemAtIndex(5).item).toBe(items[0]);
+    expect(dm.getItemAtIndex(-1).item).toBe(items[2]);
+
+    dm.state.value = [items[1]];
+    expect(dm.getItemAtIndex(0).item).toBe(items[0]); // index 0 starts in value list
+    expect(dm.getItemAtIndex(1).item).toBe(items[1]); // index 1 starts after value list
+    expect(dm.getItemAtIndex(5).item).toBe(items[0]); // out of bound leads to index 0 which is in value list
+    expect(dm.getItemAtIndex(-1).item).toBe(items[2]);
+
+    dm.context = {multiple: true};
+    dm.state.value = [];
+
+    expect(dm.getItemAtIndex(0).item).toBe(items[0]);
+    expect(dm.getItemAtIndex(5).item).toBe(items[0]);
+    expect(dm.getItemAtIndex(-1).item).toBe(items[2]);
+
+    dm.state.value = [items[1]];
+    expect(dm.getItemAtIndex(0).item).toBe(items[1]); // index 0 starts in value list
+    expect(dm.getItemAtIndex(1).item).toBe(items[0]); // index 1 starts after value list
+    expect(dm.getItemAtIndex(5).item).toBe(items[1]); // out of bound leads to index 0 which is in value list
+    expect(dm.getItemAtIndex(-1).item).toBe(items[2]);
+  });
+});

--- a/tests/ws-dropdown/dropdown-menu.spec.js
+++ b/tests/ws-dropdown/dropdown-menu.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import {React} from 'imports';
 import {DropdownMenu} from '../../src/ws-dropdown/dropdown-menu';
 

--- a/tests/ws-dropdown/dropdown-menu.spec.js
+++ b/tests/ws-dropdown/dropdown-menu.spec.js
@@ -37,7 +37,7 @@ describe('A DropdownMenu', () => {
     expect(dm.getItemAtIndex(0).item).toBe(items[0]); // index 0 starts in value list
     expect(dm.getItemAtIndex(1).item).toBe(items[1]); // index 1 starts after value list
     expect(dm.getItemAtIndex(5).item).toBe(items[0]); // out of bound leads to index 0 which is in value list
-    expect(dm.getItemAtIndex(-1).item).toBe(items[2]);
+    expect(dm.getItemAtIndex(-1).item).toBe(items[2]); // index lower than 0 leads to the last item
 
     dm.context = {multiple: true};
     dm.state.value = [];
@@ -50,6 +50,6 @@ describe('A DropdownMenu', () => {
     expect(dm.getItemAtIndex(0).item).toBe(items[1]); // index 0 starts in value list
     expect(dm.getItemAtIndex(1).item).toBe(items[0]); // index 1 starts after value list
     expect(dm.getItemAtIndex(5).item).toBe(items[1]); // out of bound leads to index 0 which is in value list
-    expect(dm.getItemAtIndex(-1).item).toBe(items[2]);
+    expect(dm.getItemAtIndex(-1).item).toBe(items[2]); // index lower than 0 leads to the last item
   });
 });

--- a/tests/ws-dropdown/ws-dropdown.spec.js
+++ b/tests/ws-dropdown/ws-dropdown.spec.js
@@ -1,0 +1,66 @@
+/* eslint-disable */
+import {React} from 'imports';
+import {TestComponent} from '../test-component';
+import {WSDropdown} from '../../src/ws-dropdown/ws-dropdown';
+
+describe('A WSDropdown', () => {
+
+  it('tracks clicks outside of dropdown', () => {
+    const dd = new TestComponent(<WSDropdown type="select"/>);
+    spyOn(dd.component, 'close');
+
+    expect(dd.component.close).not.toHaveBeenCalled();
+
+    dd.component.onDocumentClick({target: dd.component.trigger});
+    expect(dd.component.close).not.toHaveBeenCalled();
+
+    dd.component.onDocumentClick({target: document.body});
+    expect(dd.component.close).toHaveBeenCalled();
+  });
+
+  it('toggles dropdown when clicking the trigger', () => {
+    const dd = new TestComponent(<WSDropdown type="select"/>);
+    spyOn(dd.component, 'open').and.callThrough();
+    spyOn(dd.component, 'close').and.callThrough();
+
+    // Open
+    dd.component.onTriggerClick(new Event('click'));
+    expect(dd.component.open).toHaveBeenCalledTimes(1);
+    // Close
+    dd.component.onTriggerClick(new Event('click'));
+    expect(dd.component.open).toHaveBeenCalledTimes(1);
+    expect(dd.component.close).toHaveBeenCalledTimes(1);
+    // Open
+    dd.component.onTriggerClick(new Event('click'));
+    expect(dd.component.open).toHaveBeenCalledTimes(2);
+  });
+
+  it('closes dropdown on escape key', () => {
+    const dd = new WSDropdown({type: 'button'});
+    spyOn(dd, 'close');
+
+    dd.onGlobalKeyDown({key: 'ArrowUp'});
+    expect(dd.close).not.toHaveBeenCalled();
+    dd.onGlobalKeyDown({key: 'Escape'});
+    expect(dd.close).toHaveBeenCalled();
+  });
+
+  it('get\'s text from value for selects', () => {
+    const dd = new WSDropdown({type: 'select'});
+    expect(dd.getTextFromValue('test')).toEqual('test');
+    expect(dd.getTextFromValue(['test', 'asd'])).toEqual('test, asd');
+    expect(dd.getTextFromValue({label: 'test'})).toEqual('test');
+    expect(dd.getTextFromValue([{label: 'test'}, {label: 'asd'}])).toEqual('test, asd');
+  });
+
+  it('creates states', () => {
+    const dd = new WSDropdown({items: ['test', 'asd', 'qwerty'], value: 'asd', text: 'new text'});
+    expect(dd.state.items[0].selected).toBeFalsy();
+    expect(dd.state.items[0].stored).toBeFalsy();
+    expect(dd.state.items[1].selected).toBeTruthy();
+    expect(dd.state.items[1].stored).toBeTruthy();
+    expect(dd.state.items[2].selected).toBeFalsy();
+    expect(dd.state.items[2].stored).toBeFalsy();
+    expect(dd.state.text).toEqual('new text');
+  });
+});

--- a/tests/ws-dropdown/ws-dropdown.spec.js
+++ b/tests/ws-dropdown/ws-dropdown.spec.js
@@ -45,7 +45,7 @@ describe('A WSDropdown', () => {
     expect(dd.close).toHaveBeenCalled();
   });
 
-  it('get\'s text from value for selects', () => {
+  it('gets text from value for selects', () => {
     const dd = new WSDropdown({type: 'select'});
     expect(dd.getTextFromValue('test')).toEqual('test');
     expect(dd.getTextFromValue(['test', 'asd'])).toEqual('test, asd');


### PR DESCRIPTION
To improve the usability I made the dropdown controllable with keyboard.
Use arrow down / up to focus the next or previous item.
Use enter to select / store the focused item.
For multi select's you still have to hit the OK button which can be done with tab + enter.

Note: There are still some small issues in when marking an item as selected and pressing down key again the focus jumps down to the previous selection. This is not critical but I have no more time to fix this.

As well I added unit tests for the most important functions.

@tonysaad Here you can see how I workaround the React event handling :)
