### PR TITLE
Update project URL in Circle CI configuration

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ general:
 checkout:
   post:
     - git pull origin ${CIRCLE_BRANCH}
-    - git clone git@github.com:wholesale-design-system/styleguide.git
+    - git clone git@github.com:fabric-design/styleguide.git
     - git config --global user.email t.schlage@gmx.net
     - git config --global user.name "${CIRCLE_PROJECT_USERNAME}"
 


### PR DESCRIPTION
This PR updates git URL in Circle CI configuration, so the CI builds no longer fail.

