### PR TITLE
fix(header): Fixed parsing name from token

### DIFF
--- a/src/ws-header/ws-header.js
+++ b/src/ws-header/ws-header.js
@@ -89,7 +89,9 @@ export class WSHeader extends Component {
    */
   static getUserAbbreviation() {
     try {
-      const json = JSON.parse(atob(this.getAccessToken()));
+      const token = this.getAccessToken();
+      const parts = token.split('.');
+      const json = JSON.parse(atob(parts[1]));
       // Find key which contains the name
       const nameKey = Object.keys(json).find(key => key.includes('managed-id'));
       return json[nameKey];

--- a/tests/ws-header/ws-header.spec.js
+++ b/tests/ws-header/ws-header.spec.js
@@ -32,7 +32,7 @@ describe('A WSHeader', () => {
   });
 
   it('get\'s the user abbreviation from access token', () => {
-    const tokenName = btoa('{"test": "asd", "asdasdmanaged-id": "supercooluser"}');
+    const tokenName = 'asd34.' + btoa('{"test": "asd", "asdasdmanaged-id": "supercooluser"}') + '.435dg4';
     // Only test the basic function, the general authorization ist tested elsewhere
     WSHeader.storage.set('access_token', tokenName);
     expect(WSHeader.getUserAbbreviation()).toBe('supercooluser');


### PR DESCRIPTION
I forgot that the access token consist of 3 parts which I added right now