### PR TITLE
feat(header): Added a wrapper for the access token to check expiration of token

### DIFF
--- a/src/ws-header/access-token.js
+++ b/src/ws-header/access-token.js
@@ -1,0 +1,75 @@
+
+const log = console;
+/**
+ * This class represents a JWT token
+ */
+export class JsonWebToken {
+
+  /**
+   * Set the token
+   * @param {string} token Json Web Token
+   */
+  constructor(token) {
+    this.token = token;
+  }
+
+  /**
+   * Parse the token into an object
+   * @returns {Object}
+   * @private
+   */
+  getParsedToken() {
+    if (!this.parsedToken) {
+      const parts = this.token.split('.');
+      this.parsedToken = JSON.parse(atob(parts[1]));
+    }
+    return this.parsedToken;
+  }
+
+  /**
+   * Determine if the token is still valid
+   * @returns {boolean}
+   */
+  isValid() {
+    try {
+      const tokenObject = this.getParsedToken();
+      const expiresAt = parseInt(tokenObject.exp, 10) * 1000;
+      return new Date().getTime() < expiresAt;
+    } catch (e) {
+      log.warn('The validity of the token could not be determined');
+    }
+    return false;
+  }
+
+  /**
+   * Get the user abbreviation the token was issued for
+   * @returns {string}
+   */
+  getUserAbbreviation() {
+    try {
+      const tokenObject = this.getParsedToken();
+      // Find key which contains the name
+      const nameKey = Object.keys(tokenObject).find(key => key.includes('managed-id'));
+      return tokenObject[nameKey];
+    } catch (e) {
+      log.warn('The validity of the token could not be determined');
+    }
+    return null;
+  }
+
+  /**
+   * Return the real token
+   * @returns {string}
+   */
+  valueOf() {
+    return this.token;
+  }
+
+  /**
+   * Return the real token
+   * @returns {string}
+   */
+  toString() {
+    return this.token;
+  }
+}

--- a/src/ws-header/ws-header.js
+++ b/src/ws-header/ws-header.js
@@ -84,7 +84,7 @@ export class WSHeader extends Component {
   /**
    * Tries to get the access token from authorization class
    * @param {string} queryString The current query string to parse the token from
-   * @returns {string|null}
+   * @returns {JsonWebToken|null}
    */
   static getAccessToken(queryString = location.hash.substr(1)) {
     if (!this.authorization.accessToken) {
@@ -99,23 +99,6 @@ export class WSHeader extends Component {
    */
   static removeAccessToken() {
     this.authorization.unauthorize();
-  }
-
-  /**
-   * Get abbreviation for the user the access token is issued for
-   * @returns {string|null}
-   */
-  static getUserAbbreviation() {
-    try {
-      const token = this.getAccessToken();
-      const parts = token.split('.');
-      const json = JSON.parse(atob(parts[1]));
-      // Find key which contains the name
-      const nameKey = Object.keys(json).find(key => key.includes('managed-id'));
-      return json[nameKey];
-    } catch (e) {
-      return null;
-    }
   }
 
   /**

--- a/tests/ws-header/ws-header.spec.js
+++ b/tests/ws-header/ws-header.spec.js
@@ -28,15 +28,15 @@ describe('A WSHeader', () => {
     const tokenName = 'asd';
     // Only test the basic function, the general authorization ist tested elsewhere
     WSHeader.storage.set('access_token', tokenName);
-    expect(WSHeader.getAccessToken()).toBe(tokenName);
+    expect(`${WSHeader.getAccessToken()}`).toBe(tokenName);
   });
 
   it('get\'s the user abbreviation from access token', () => {
     const tokenName = 'asd34.' + btoa('{"test": "asd", "asdasdmanaged-id": "supercooluser"}') + '.435dg4';
     // Only test the basic function, the general authorization ist tested elsewhere
     WSHeader.storage.set('access_token', tokenName);
-    expect(WSHeader.getUserAbbreviation()).toBe('supercooluser');
-    expect(WSHeader.getAccessToken()).toBe(tokenName);
+    expect(WSHeader.getAccessToken().getUserAbbreviation()).toBe('supercooluser');
+    expect(`${WSHeader.getAccessToken()}`).toBe(tokenName);
   });
 
   it('doesn\'t get an access token', () => {


### PR DESCRIPTION
Instead of return the access token as string and exposing many token related functions from the header I wrapped the token with a class.
This class allows to get the abbreviation of the user the token was issued for and to check if the token is valid based on the expiration date and JSON structure.

```js
WSHeader.storage.set('access_token', 'some.jwt.token');
const token = WSHeader.getAccessToken()
token.isValid() // Returns true if token is not expired
token.getUserAbbreviation() // Returns abbreviation of user the token was issued for e.g. tschlage
token == 'some.jwt.token' // will be true because valueOf returns the token
token === 'some.jwt.token' // will be false because the type is still JsonWebToken
`The token is: ${token}` // The JsonWebToken class implements a toString method
```