### PR TITLE
feat(header) Accept custom link elements

### DIFF
--- a/demo/demo_app.js
+++ b/demo/demo_app.js
@@ -23,7 +23,16 @@ render(
       appName="Demo Page"
       clientId="stups_abba-frontend-release_180e00be-2b66-4e44-ac95-37f10068c015"
       links={[
-        (<WSDropdown text="Multiple" type="button" width="500px" placeholder="placeholder!" items={['Save']}/>),
+        (<WSDropdown
+          text="Multiple" type="button" width="500px" placeholder="Filter values.." selectAll filterable multiple items={[
+            'New',
+            'New From Template',
+            'Open',
+            'Test value 1',
+            'Open Recent',
+            'Save'
+          ]}
+        />),
         {label: 'Link', href: '#LinkValue', onClick: value => console.log(value)},
         {
           label: 'Link2',

--- a/demo/demo_app.js
+++ b/demo/demo_app.js
@@ -23,16 +23,7 @@ render(
       appName="Demo Page"
       clientId="stups_abba-frontend-release_180e00be-2b66-4e44-ac95-37f10068c015"
       links={[
-        (<WSDropdown
-          text="Multiple" type="button" width="500px" placeholder="Filter values.." selectAll filterable multiple items={[
-            'New',
-            'New From Template',
-            'Open',
-            'Test value 1',
-            'Open Recent',
-            'Save'
-          ]}
-        />),
+        (<WSDropdown text="Multiple" type="button" width="500px" placeholder="placeholder!" items={['Save']}/>),
         {label: 'Link', href: '#LinkValue', onClick: value => console.log(value)},
         {
           label: 'Link2',

--- a/doc/components/01-header.md
+++ b/doc/components/01-header.md
@@ -27,6 +27,24 @@ To use Header simply embed the ws-header in your application and import the scss
 </ws-header>
 ```
 
+## Alternate Link Components
+If you need to use an alternate link component (such as, in this example, a Link component from react router) simply pass it instead of the link config object and it will be rendered in it's place.
+```html
+import { Link } from 'react-router-dom';
+
+<ws-header
+  appName="Demo Page"
+  links={[
+    (<Link to="/nmm">Somewhere</Link>),
+    {
+      label: 'Link',
+      href: 'LinkValue',
+      onClick: (value) => console.log(value)
+    },
+  ]}>
+</ws-header>
+```
+
 ## Persistence
 These header component has to persist several values during page reloads. For instance the selected locale
 or the requested access token and it's expiration time. Per default the header will use the local storage

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "build": "gulp build && npm run package",
     "start": "npm run start:react",
-    "start:react": "webpack-dev-server --progress --colors --config webpack.config.react.js",
-    "start:preact": "webpack-dev-server --watch --config webpack.config.preact.js",
+    "start:react": "webpack-dev-server --progress --colors --watch --config webpack.config.react.js",
+    "start:preact": "webpack-dev-server --progress --colors --watch --config webpack.config.preact.js",
     "test": "gulp test",
     "test:react": "gulp test:react",
     "test:preact": "gulp test:preact",

--- a/src/ws-header/ws-header.js
+++ b/src/ws-header/ws-header.js
@@ -273,6 +273,19 @@ export class WSHeader extends Component {
   }
 
   /**
+   * codeclimate demands abstraction; this makes links
+   * @param  {Object} link link data, label, href, etc
+   * @return {JSX} a rendered link
+   */
+  renderLink(link) {
+    return (
+      <a href={link.href} onClick={event => { if (link.onClick) link.onClick(event); }}>
+        {link.label}
+      </a>
+    );
+  }
+
+  /**
    * @returns {Object}
    */
   render() {
@@ -280,9 +293,9 @@ export class WSHeader extends Component {
       <header className="ws-header" ref={element => { this.element = element; }}>
         <div className="level-1">
          {
-            rootUrl.$$typeof ? rootUrl : <a // eslint-disable-line jsx-a11y/href-no-hash
+            this.props.rootUrl.$$typeof ? this.props.rootUrl : <a // eslint-disable-line jsx-a11y/href-no-hash
               className="application-name"
-              href={rootUrl}
+              href={this.props.rootUrl}
             >
               {this.props.appLogo &&
                 <figure className="application-logo">
@@ -302,7 +315,7 @@ export class WSHeader extends Component {
                   ref={element => { this.menuItems[index] = element; }}
                   className={(link.isCurrent) ? 'is-current' : null}
                 >
-                  {link.$$typeof ? link: this.renderLink(link)}
+                  {link.$$typeof ? link : this.renderLink(link)}
                 </li>
               )}
             </ul>

--- a/src/ws-header/ws-header.js
+++ b/src/ws-header/ws-header.js
@@ -279,17 +279,19 @@ export class WSHeader extends Component {
     return (
       <header className="ws-header" ref={element => { this.element = element; }}>
         <div className="level-1">
-          <a // eslint-disable-line jsx-a11y/href-no-hash
-            className="application-name"
-            href={this.props.rootUrl}
-          >
-            {this.props.appLogo &&
-              <figure className="application-logo">
-                <img src={this.props.appLogo} alt="Application logo" />
-              </figure>
-            }
-            {this.props.appName}
-          </a>
+         {
+            rootUrl.$$typeof ? rootUrl : <a // eslint-disable-line jsx-a11y/href-no-hash
+              className="application-name"
+              href={rootUrl}
+            >
+              {this.props.appLogo &&
+                <figure className="application-logo">
+                  <img src={this.props.appLogo} alt="Application logo" />
+                </figure>
+              }
+              {this.props.appName}
+            </a>
+          }
           <nav className="main-menu">
             <ul>
               {this.props.links.map((link, index) =>


### PR DESCRIPTION
for #167 

Pull request for issue: LBJ-716

links arent always simple anchors.  in my example i needed a `<Link />` element (react router link) instead of an `<a />`.  this will detect something that isn't a standard object and render it as a component instead

