### PR TITLE
fix(datepicker) disabled pointer events on the icon

### DIFF
--- a/src/ws-date-picker/ws-date-picker.scss
+++ b/src/ws-date-picker/ws-date-picker.scss
@@ -2,6 +2,7 @@
   position: relative;
   display: inline-block;
   &.with-input .icon {
+    pointer-events: none;
     position: absolute;
     right: rem(10px);
     top: rem(10px);


### PR DESCRIPTION
now you can click through to the input

Pull request for issue: #179 

Component Screenshot:

<img width="659" alt="screen shot 2018-06-20 at 17 56 07" src="https://user-images.githubusercontent.com/1480168/41669933-3fc25082-74b3-11e8-8d63-c0a08d84c003.png">


