### PR TITLE
fix(dropdown): Fixed initial text for select dropdowns

### DIFF
--- a/demo/demo_app.js
+++ b/demo/demo_app.js
@@ -110,7 +110,7 @@ render(
       />
       <br />
       <WSDropdown
-        text="Simple Wide" type="select" filterable items={[
+        text="Simple Wide 2" type="select" filterable items={[
           'New',
           {
             label: 'New From Template',

--- a/src/ws-dropdown/ws-dropdown.js
+++ b/src/ws-dropdown/ws-dropdown.js
@@ -204,8 +204,10 @@ export class WSDropdown extends Component {
     let text = propsText || (this.state && this.state.text ? this.state.text : '');
     // Check if we have to update the text value
     if (this.props.type === 'select') {
-      if (Array.isArray(value) && value.length) {
-        text = value.map(item => item.label || item).join(', ');
+      if (Array.isArray(value)) {
+        if (value.length) {
+          text = value.map(item => item.label || item).join(', ');
+        }
       } else if (value) {
         // Value can be object from dropdown item or simple string from input
         text = value.label || value;


### PR DESCRIPTION
Team Azubis reported an issue with dropdowns when they have type=select and text=anything. The default text is not displayed.

I fixed this issue.