### PR TITLE
Fixed not changeable filter inputs

### DIFF
--- a/src/ws-dropdown/dropdown-menu.js
+++ b/src/ws-dropdown/dropdown-menu.js
@@ -472,7 +472,7 @@ export class DropdownMenu extends Component {
           <li className="dropdown-input" key="filter">
             <input
               type="text"
-              value={this.state.filter}
+              defaultValue={this.state.filter}
               placeholder={this.props.placeholder}
               ref={element => { this.input = element; }}
             />

--- a/src/ws-multi-select/ws-multi-select.js
+++ b/src/ws-multi-select/ws-multi-select.js
@@ -133,7 +133,7 @@ export class WSMultiSelect extends WSDropdown {
         <input
           type="text"
           placeholder={this.props.placeholder}
-          value={this.state.filter}
+          defaultValue={this.state.filter}
           ref={element => { this.input = element; }}
         />
         <span className="icon icon16 icon-magnifiying-glass" ref={element => { this.icon = element; }} />


### PR DESCRIPTION
The filter inputs of dropdown and multi select were not changeable anymore due to diffences of defaultValue and value in React.