### PR TITLE
fix(overlay): Fixed broken components when blurring the tab

### DIFF
--- a/src/ws-dropdown/dropdown-menu.js
+++ b/src/ws-dropdown/dropdown-menu.js
@@ -439,6 +439,7 @@ export class DropdownMenu extends Component {
       ANIMATION_END_EVENTS.forEach(eventName => {
         item.removeEventListener(eventName, handler);
       });
+      window.removeEventListener('blur', handler);
       item.classList.remove(animationClass);
       callback(item);
     };
@@ -446,6 +447,9 @@ export class DropdownMenu extends Component {
     ANIMATION_END_EVENTS.forEach(eventName => {
       item.addEventListener(eventName, handler);
     });
+    // Force execute callback when window is blurred because browsers stop css animations and this leads to
+    // problems as the rendering is resumed after focus again.
+    window.addEventListener('blur', handler);
     // Increase started event counter for each animation start event
     ANIMATION_START_EVENTS.forEach(eventName => {
       item.addEventListener(eventName, () => { eventCounter += 1; });

--- a/src/ws-overlay/ws-overlay.js
+++ b/src/ws-overlay/ws-overlay.js
@@ -170,18 +170,21 @@ export class WSOverlay extends Component {
    */
   animateElement(item, animationClass, callback) {
     // Define callback for animation end events
-    const getEventHandler = eventName => {
-      const eventHandler = () => {
-        item.classList.remove(animationClass);
+    const eventHandler = () => {
+      item.classList.remove(animationClass);
+      ANIMATION_END_EVENTS.forEach(eventName => {
         item.removeEventListener(eventName, eventHandler);
-        callback(item);
-      };
-      return eventHandler;
+      });
+      window.removeEventListener('blur', eventHandler);
+      callback(item);
     };
     // Listen for all possible animation end events
     ANIMATION_END_EVENTS.forEach(eventName => {
-      item.addEventListener(eventName, getEventHandler(eventName));
+      item.addEventListener(eventName, eventHandler);
     });
+    // Force execute callback when window is blurred because browsers stop css animations and this leads to
+    // problems as the rendering is resumed after focus again.
+    window.addEventListener('blur', eventHandler);
     // Add class to start animation
     item.classList.add(animationClass);
   }


### PR DESCRIPTION
**Explanation of the error:**
A component opens the dropdown when a input got focus and closes the dropdown when blurred. The close works by adding a css class to animate the element and a listener removes mod-open class when the animation is done. When you focus the input and the dd is opened and then switch the tab, chrome and ff will trigger a blur event, the animation is started but actually chrome and ff are not rendering anything. When you then focus the original tab again, the input will be focused and the dropdown is opened and finally chrome renders the close animation^^ At this point the dropdown thinks it's open but it isn't and it's broken. 

**Solution**
before starting the animation add another listener for window blurring to immediately call the callback like the animation would be done.