### PR TITLE
fix(overlay): Fixed corrupted state when call open() and close() to fast and often

### DIFF
--- a/src/ws-multi-select/ws-multi-select.js
+++ b/src/ws-multi-select/ws-multi-select.js
@@ -21,7 +21,6 @@ export class WSMultiSelect extends WSDropdown {
    * @returns {void}
    */
   componentDidMount() {
-    window.select = this;
     this.icon.addEventListener('click', this.onClickIcon);
     this.input.addEventListener('keyup', this.onKeyUp);
     this.input.addEventListener('focus', this.onFocus);

--- a/src/ws-overlay/ws-overlay.js
+++ b/src/ws-overlay/ws-overlay.js
@@ -49,6 +49,7 @@ export class WSOverlay extends Component {
   constructor(props) {
     super(props);
     this.contentHeight = 0;
+    this.animations = [];
   }
 
   /**
@@ -97,6 +98,8 @@ export class WSOverlay extends Component {
    * @returns {void}
    */
   open() {
+    // Animations could be finished after open function and this would remove mod-open and the height again
+    this.finishAnimations();
     // Stop if this dropdown is already opened or close previous opened dropdown
     if (WSOverlay.openOverlay === this) {
       return;
@@ -187,6 +190,19 @@ export class WSOverlay extends Component {
     window.addEventListener('blur', eventHandler);
     // Add class to start animation
     item.classList.add(animationClass);
+
+    this.animations.push(eventHandler);
+  }
+
+  /**
+   * Helper method to finish animations when the element changes and they are not done yet
+   * @returns {void}
+   */
+  finishAnimations() {
+    this.animations.forEach(eventHandler => {
+      eventHandler();
+    });
+    this.animations = [];
   }
 
   /**


### PR DESCRIPTION
The problem was that close removes the container height and the class mod-open once the animation is finished.
When open() is called within these 200ms the target height is set on the container and the class mod-open is added, then the animatiion finishes and the height and mod-open is removed again.
Afterwards close() can be called again but since there is no change (class already removed and height is 0) the animation end events are never fired and the listener is not removed. So this effect
will be repeated on the next open() and close() call.

To work around this I call the animation end callbacks of started animations before opening the overlay.