### PR TITLE
fix(inline-edit): Resize inline edit when value changes from outside

### DIFF
--- a/src/ws-inline-edit/ws-inline-edit.js
+++ b/src/ws-inline-edit/ws-inline-edit.js
@@ -57,7 +57,9 @@ export class WSInlineEdit extends Component {
    * @returns {void}
    */
   componentWillReceiveProps(props) {
-    this.setState(this.createState(props));
+    this.setState(this.createState(props), () => {
+      this.resizeInput();
+    });
   }
 
   /**


### PR DESCRIPTION
**Problem**
When the value property changed from outside the value of the input is updated but the width isn't recalculated.

**Solution**
Resize the input after the state change.