### PR TITLE
fix(inline-edit): Fixed inline edit size calculation for firefox

### DIFF
--- a/src/ws-inline-edit/ws-inline-edit.js
+++ b/src/ws-inline-edit/ws-inline-edit.js
@@ -218,8 +218,14 @@ export class WSInlineEdit extends Component {
     const calculator = document.createElement('div');
     calculator.style.fontSize = style.fontSize || '16px';
     calculator.style.lineHeight = style.lineHeight || '16px';
-    calculator.style.margin = style.margin;
-    calculator.style.padding = style.padding;
+    calculator.style.marginTop = style.marginTop;
+    calculator.style.marginLeft = style.marginLeft;
+    calculator.style.marginRight = style.marginRight;
+    calculator.style.marginBottom = style.marginBottom;
+    calculator.style.paddingTop = style.paddingTop;
+    calculator.style.paddingLeft = style.paddingLeft;
+    calculator.style.paddingRight = style.paddingRight;
+    calculator.style.paddingBottom = style.paddingBottom;
     calculator.style.visibility = 'hidden';
     calculator.style.position = 'absolute';
     calculator.style.top = '-1000px';


### PR DESCRIPTION
Firefox doesn't have a filled padding or margin property if site specific properties like padding-left were used.